### PR TITLE
Address var not found in index error

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    added:
+    - Updated categorical dummy encoding to restore original columns when dummies are not generated (edge case for when there is a single category).


### PR DESCRIPTION
Fix #102 

When no dummies are created, if the "categorical" variable is of numeric type, this implementation restores the original variable. When the "categorical" variable is non-numeric, it converts its unique value to 1.0 and stores the original to introduce back in the post-processing step taking place after imputation.

@MaxGhenis I tested locally and it seems like this fixes the error in -us-data. 

When running sim.calculate() on the puf dataset two variables `long_term_capital_gains_on_collectibles` and `recapture_of_investment_credit` have almost all their values become 0.0. this was probably breaking imputation as all values would be 0.0 after data sampling. 

```python
print("ltcg", (puf_sim.calculate("long_term_capital_gains_on_collectibles").values != 0).sum())
print("recapture", (puf_sim.calculate("recapture_of_investment_credit").values != 0).sum())

ltcg 3
recapture 0
```