### PR TITLE
Add Python 3.14 support, bump deps, upgrade GitHub Actions

### DIFF
--- a/.github/workflows/pr_code_changes.yaml
+++ b/.github/workflows/pr_code_changes.yaml
@@ -7,9 +7,9 @@ jobs:
   Lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.14"
       - name: Install uv
@@ -25,7 +25,7 @@ jobs:
     outputs:
       mdn_changed: ${{ steps.check.outputs.mdn_changed }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Check for MDN-related file changes
@@ -55,11 +55,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install uv
         uses: astral-sh/setup-uv@v5
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install slim version
@@ -106,7 +106,7 @@ jobs:
           name: microimputation-results-${{ github.sha }}
           path: microimputation-dashboard/public/microimputation_results.csv
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         with:
           file: ./coverage.xml
           fail_ci_if_error: false

--- a/.github/workflows/pr_docs_changes.yaml
+++ b/.github/workflows/pr_docs_changes.yaml
@@ -24,7 +24,7 @@ jobs:
           - name: Set up Python
             uses: actions/setup-python@v5
             with:
-                python-version: '3.13'
+                python-version: '3.14'
               
           - name: Install R and dependencies
             run: |

--- a/.github/workflows/versioning.yaml
+++ b/.github/workflows/versioning.yaml
@@ -24,7 +24,7 @@ jobs:
             - name: Setup Python
               uses: actions/setup-python@v5
               with:
-                python-version: 3.13
+                python-version: 3.14
             - name: Bump version and build changelog
               run: |
                 pip install towncrier
@@ -41,7 +41,7 @@ jobs:
       runs-on: ubuntu-latest
       strategy:
         matrix:
-          python-version: ["3.13"]
+          python-version: ["3.14"]
       steps:
         - name: Checkout code
           uses: actions/checkout@v4

--- a/changelog.d/python-3.14.changed.md
+++ b/changelog.d/python-3.14.changed.md
@@ -1,1 +1,1 @@
-Added Python 3.14 support and made it the default CI version.
+Added Python 3.14 support, bumped dependency upper bounds (pandas, plotly, scipy, pytest, pytest-cov), and upgraded GitHub Actions versions.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,10 +17,10 @@ authors = [
 requires-python = ">=3.12,<3.15"
 dependencies = [
     "numpy>=2.0.0,<3.0.0",
-    "pandas>=2.2.0,<3.0.0",
-    "plotly>=5.24.0,<6.0.0",
+    "pandas>=2.2.0,<4.0.0",
+    "plotly>=5.24.0,<7.0.0",
     "scikit-learn>=1.7.0,<2.0.0",
-    "scipy>=1.16.0,<1.17.0",
+    "scipy>=1.16.0,<2.0.0",
     "requests>=2.32.0,<3.0.0",
     "tqdm>=4.65.0,<5.0.0",
     "statsmodels>=0.14.5,<0.16.0",
@@ -33,8 +33,8 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "pytest>=8.0.0,<9.0.0",
-    "pytest-cov>=6.0.0,<7.0.0",
+    "pytest>=8.0.0,<10.0.0",
+    "pytest-cov>=6.0.0,<8.0.0",
     "ruff>=0.9.0",
     "mypy>=1.2.3,<2.0.0",
     "build>=1.2.0,<2.0.0",
@@ -54,7 +54,7 @@ docs = [
     "jupyter-book",
     "furo>=2024.0.0",  # Sphinx theme for documentation
     "ipywidgets>=8.0.0,<9.0.0",
-    "plotly>=5.24.0,<6.0.0",
+    "plotly>=5.24.0,<7.0.0",
     "h5py>=3.1.0,<4.0.0",
 ]
 


### PR DESCRIPTION
## Summary

- Bump `requires-python` from `<3.14` to `<3.15`
- Update CI matrix to 3.12 (smoke) + 3.14 (full) across all workflows
- Widen dependency upper bounds: pandas `<4.0.0`, plotly `<7.0.0`, scipy `<2.0.0`, pytest `<10.0.0`, pytest-cov `<8.0.0`
- Upgrade GitHub Actions: checkout v3→v4, setup-python v4→v5, codecov-action v3→v5

## Test plan

- [ ] CI passes on both Python 3.12 and 3.14
- [ ] No dependency resolution failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)