### PR TITLE
Update GitHub Actions for Node 24 runtime

### DIFF
--- a/.github/workflows/changelog_entry.yaml
+++ b/.github/workflows/changelog_entry.yaml
@@ -9,7 +9,7 @@ jobs:
     name: Check changelog fragment
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Check for changelog fragment
         run: |
           FRAGMENTS=$(find changelog.d -type f ! -name '.gitkeep' | wc -l)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Build HTML Assets
         run: myst build --html
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: './_build/html'
       - name: Deploy to GitHub Pages

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,10 +29,10 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup Pages
-        uses: actions/configure-pages@v3
-      - uses: actions/setup-node@v4
+        uses: actions/configure-pages@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 18.x
       - name: Install MyST
@@ -45,4 +45,4 @@ jobs:
           path: './_build/html'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,6 +62,6 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v6
         with:
-          file: ./coverage.xml
+          files: ./coverage.xml
           fail_ci_if_error: false
           verbose: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,11 +13,11 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.1.0
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install R and dependencies (Python 3.13 only)
@@ -55,12 +55,12 @@ jobs:
           python examples/pipeline.py
       - name: Upload microimputation results
         if: always() && matrix.python-version == '3.13'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: microimputation-results-${{ github.sha }}
           path: microimputation-dashboard/public/microimputation_results.csv
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v6
         with:
           file: ./coverage.xml
           fail_ci_if_error: false

--- a/.github/workflows/pr_code_changes.yaml
+++ b/.github/workflows/pr_code_changes.yaml
@@ -7,13 +7,13 @@ jobs:
   Lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.14"
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.1.0
       - name: Install relevant dependencies
         run: |
           uv pip install "ruff>=0.9.0" --system
@@ -25,7 +25,7 @@ jobs:
     outputs:
       mdn_changed: ${{ steps.check.outputs.mdn_changed }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Check for MDN-related file changes
@@ -55,11 +55,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.1.0
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install slim version
@@ -104,7 +104,7 @@ jobs:
           python examples/pipeline.py
       - name: Upload microimputation results
         if: always() && matrix.python-version == '3.14'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: microimputation-results-${{ github.sha }}
           path: microimputation-dashboard/public/microimputation_results.csv

--- a/.github/workflows/pr_code_changes.yaml
+++ b/.github/workflows/pr_code_changes.yaml
@@ -109,8 +109,8 @@ jobs:
           name: microimputation-results-${{ github.sha }}
           path: microimputation-dashboard/public/microimputation_results.csv
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
-          file: ./coverage.xml
+          files: ./coverage.xml
           fail_ci_if_error: false
           verbose: true

--- a/.github/workflows/pr_docs_changes.yaml
+++ b/.github/workflows/pr_docs_changes.yaml
@@ -17,12 +17,12 @@ jobs:
       name: Test documentation builds
       steps:
           - name: Checkout repo
-            uses: actions/checkout@v4
+            uses: actions/checkout@v6
           - name: Install uv
-            uses: astral-sh/setup-uv@v5
+            uses: astral-sh/setup-uv@v8.1.0
 
           - name: Set up Python
-            uses: actions/setup-python@v5
+            uses: actions/setup-python@v6
             with:
                 python-version: '3.14'
               

--- a/.github/workflows/versioning.yaml
+++ b/.github/workflows/versioning.yaml
@@ -19,17 +19,17 @@ jobs:
         steps:
             - name: Generate GitHub App token
               id: app-token
-              uses: actions/create-github-app-token@v1
+              uses: actions/create-github-app-token@v3
               with:
                 app-id: ${{ secrets.APP_ID }}
                 private-key: ${{ secrets.APP_PRIVATE_KEY }}
             - name: Checkout repo
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
               with:
                 token: ${{ steps.app-token.outputs.token }}
                 fetch-depth: 0
             - name: Setup Python
-              uses: actions/setup-python@v5
+              uses: actions/setup-python@v6
               with:
                 python-version: 3.14
             - name: Bump version and build changelog
@@ -38,7 +38,7 @@ jobs:
                 python .github/bump_version.py
                 towncrier build --yes --version $(python -c "import re; print(re.search(r'version = \"(.+?)\"', open('pyproject.toml').read()).group(1))")
             - name: Update changelog
-              uses: EndBug/add-and-commit@v9
+              uses: EndBug/add-and-commit@v10
               with:
                 add: "."
                 message: Update package version
@@ -51,11 +51,11 @@ jobs:
           python-version: ["3.14"]
       steps:
         - name: Checkout code
-          uses: actions/checkout@v4
+          uses: actions/checkout@v6
           with:
             fetch-depth: 0 # Fetch all history for all tags and branches
         - name: Set up Python
-          uses: actions/setup-python@v5
+          uses: actions/setup-python@v6
           with:
             python-version: ${{ matrix.python-version }}
         - name: Install package


### PR DESCRIPTION
Updates GitHub Actions workflow action versions to releases that run on Node.js 24, removing Node.js 20 JavaScript action deprecation warnings before GitHub-hosted runners switch defaults on June 2, 2026.

This is a mechanical workflow-only change from an org-wide scan. It also updates older checkout/setup/action versions that still advertised Node.js 12 or 16 runtimes where a Node.js 24 successor is available.